### PR TITLE
Add option --mingap when importing genome

### DIFF
--- a/example_data/example_data.go
+++ b/example_data/example_data.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math/rand"
 	"path/filepath"
+	"strings"
 )
 
 func init() {
@@ -85,7 +86,9 @@ func MakeTestFiles(outdir string) {
 	fout.WriteString(">g1.c0\n")
 	fout.WriteString(string(makeRandomSeq(100)) + "\n")
 	fout.WriteString(">g1.c1\n")
-	fout.WriteString(string(makeRandomSeq(900)))
+	fout.WriteString(string(makeRandomSeq(50)))
+	fout.WriteString(strings.Repeat("N", 50))
+	fout.WriteString(string(makeRandomSeq(800)))
 	fout.WriteString(string(commonT))
 	fout.WriteString(string(makeRandomSeq(900)) + "\n")
 	fout.WriteString(">g1.c2\n")
@@ -114,7 +117,9 @@ func MakeTestFiles(outdir string) {
 	fout.WriteString("g2.c10\t.\tgene\t150\t410\t.\t+\t.\tID=gene43;foo=bar;name=name_gene43\n")
 	fout.WriteString("##FASTA\n")
 	fout.WriteString(">g2.c1\n")
-	fout.WriteString(string(makeRandomSeq(1000)) + "\n")
+	fout.WriteString(string(makeRandomSeq(800)))
+	fout.WriteString(string(strings.Repeat("N", 5)))
+	fout.WriteString(string(makeRandomSeq(195)) + "\n")
 	fout.WriteString(">g2.c2\n")
 	fout.WriteString(string(commonT) + "\n")
 	fout.WriteString(">g2.c3\n")
@@ -122,7 +127,9 @@ func MakeTestFiles(outdir string) {
 	fout.WriteString(">g2.c4\n")
 	fout.WriteString(string(bot4) + "\n")
 	fout.WriteString(">g2.c5\n")
-	fout.WriteString(string(makeRandomSeq(800)) + "\n")
+	fout.WriteString(string(makeRandomSeq(300)))
+	fout.WriteString(string(strings.Repeat("N", 100)))
+	fout.WriteString(string(makeRandomSeq(400)) + "\n")
 	fout.WriteString(">g2.c6\n")
 	fout.WriteString(string(utils.ReverseComplement(bot6)) + "\n")
 	fout.WriteString(">g2.c7\n")

--- a/main.go
+++ b/main.go
@@ -17,18 +17,20 @@ func main() {
 	var outprefix string
 	var outdir string
 	var bindir string
+	minGapLen := -1
 
 	// ---------------- import_seqfile ---------------------
 	var cmdImportSeqfile = &cobra.Command{
 		Use:   "import_seqfile",
 		Short: "Import sequence file",
 		Run: func(cmd *cobra.Command, args []string) {
-			seqfiles.ParseSeqFile(infile, outprefix)
+			seqfiles.ParseSeqFile(infile, outprefix, minGapLen)
 		},
 	}
 
 	cmdImportSeqfile.Flags().StringVarP(&infile, "infile", "i", "", "REQUIRED. Input sequence file")
 	cmdImportSeqfile.Flags().StringVarP(&outprefix, "outprefix", "o", "", "REQUIRED. Prefix of output files")
+	cmdImportSeqfile.Flags().IntVarP(&minGapLen, "mingap", "g", -1, "Minimum length of run of Ns to count as a gap and get added to annotation. Anything <= 0 means do not add any gaps")
 	cmdImportSeqfile.MarkFlagRequired("infile")
 	cmdImportSeqfile.MarkFlagRequired("outprefix")
 	rootCmd.AddCommand(cmdImportSeqfile)

--- a/seqfiles/seqfiles_test.go
+++ b/seqfiles/seqfiles_test.go
@@ -165,3 +165,38 @@ func TestParseEMBL(t *testing.T) {
 	require.True(t, filesEqual, "Annotation file %s expected contents incorrect", outfileFa)
 	utils.DeleteFileIfExists(outfileAnnot)
 }
+
+func TestGaps(t *testing.T) {
+	infile := filepath.Join("seqfiles_testdata", "getGapsFromSingleLineFasta.fa")
+	gaps := []Gap{}
+	gaps = append(gaps, Gap{SeqName: "one", Start: 1, End: 2})
+	gaps = append(gaps, Gap{SeqName: "two", Start: 4, End: 6})
+	gaps = append(gaps, Gap{SeqName: "three", Start: 1, End: 2})
+	require.Equal(t, gaps, getGapsFromSingleLineFasta(infile, 2), "Incorrect gaps in TestGetGapsFromSingleLineFasta")
+	gaps = []Gap{}
+	gaps = append(gaps, Gap{SeqName: "one", Start: 1, End: 2})
+	gaps = append(gaps, Gap{SeqName: "one", Start: 8, End: 8})
+	gaps = append(gaps, Gap{SeqName: "two", Start: 4, End: 6})
+	gaps = append(gaps, Gap{SeqName: "two", Start: 14, End: 14})
+	gaps = append(gaps, Gap{SeqName: "two", Start: 16, End: 16})
+	gaps = append(gaps, Gap{SeqName: "three", Start: 1, End: 2})
+	require.Equal(t, gaps, getGapsFromSingleLineFasta(infile), "Incorrect gaps in TestGetGapsFromSingleLineFasta")
+
+	outfileAnnot := "tmp.test.gaps.gff"
+	utils.DeleteFileIfExists(outfileAnnot)
+	addGapsToAnnotFile(gaps, outfileAnnot)
+	expectFileAnnot := filepath.Join("seqfiles_testdata", "gaps.expect.1.gff")
+	cmp := equalfile.New(nil, equalfile.Options{})
+	filesEqual, err := cmp.CompareFile(expectFileAnnot, outfileAnnot)
+	require.NoError(t, err, "Error comparing annotation files %s, %s", expectFileAnnot, outfileAnnot)
+	require.True(t, filesEqual, "Annotation file %s expected contents incorrect", outfileAnnot)
+
+	gaps = gaps[:0]
+	gaps = append(gaps, Gap{SeqName: "four", Start: 42, End: 142})
+	addGapsToAnnotFile(gaps, outfileAnnot)
+	expectFileAnnot = filepath.Join("seqfiles_testdata", "gaps.expect.2.gff")
+	filesEqual, err = cmp.CompareFile(expectFileAnnot, outfileAnnot)
+	require.NoError(t, err, "Error comparing annotation files %s, %s", expectFileAnnot, outfileAnnot)
+	require.True(t, filesEqual, "Annotation file %s expected contents incorrect", outfileAnnot)
+	utils.DeleteFileIfExists(outfileAnnot)
+}

--- a/seqfiles/seqfiles_testdata/gaps.expect.1.gff
+++ b/seqfiles/seqfiles_testdata/gaps.expect.1.gff
@@ -1,0 +1,7 @@
+##gff-version 3
+one	TNA	gap	1	2	.	+	.	name=gap
+one	TNA	gap	8	8	.	+	.	name=gap
+two	TNA	gap	4	6	.	+	.	name=gap
+two	TNA	gap	14	14	.	+	.	name=gap
+two	TNA	gap	16	16	.	+	.	name=gap
+three	TNA	gap	1	2	.	+	.	name=gap

--- a/seqfiles/seqfiles_testdata/gaps.expect.2.gff
+++ b/seqfiles/seqfiles_testdata/gaps.expect.2.gff
@@ -1,0 +1,8 @@
+##gff-version 3
+one	TNA	gap	1	2	.	+	.	name=gap
+one	TNA	gap	8	8	.	+	.	name=gap
+two	TNA	gap	4	6	.	+	.	name=gap
+two	TNA	gap	14	14	.	+	.	name=gap
+two	TNA	gap	16	16	.	+	.	name=gap
+three	TNA	gap	1	2	.	+	.	name=gap
+four	TNA	gap	42	142	.	+	.	name=gap

--- a/seqfiles/seqfiles_testdata/getGapsFromSingleLineFasta.fa
+++ b/seqfiles/seqfiles_testdata/getGapsFromSingleLineFasta.fa
@@ -1,0 +1,8 @@
+>one
+NNAGTACN
+>two
+ACANNNGCGTACANCNC
+>three
+NN
+>four
+ATATCATCT


### PR DESCRIPTION
When importing, finds gaps in input genome and adds them to output gff. Command line option `--mingap` to set min length of run of Ns to count as a gap